### PR TITLE
#3 Add text parser for Gemini summary response

### DIFF
--- a/src/summarize.py
+++ b/src/summarize.py
@@ -1,7 +1,7 @@
 from dotenv import load_dotenv
 import os
 from google import genai
-from utils import get_formatted_date
+from utils import get_formatted_date, format_gemini_response
 
 load_dotenv()
 GEMINI_API_KEY = os.getenv("GEMINI_API_KEY")
@@ -30,14 +30,15 @@ async def _run_gemini(audio_file_path: str, duration_minutes: str) -> str:
         # Define system/user prompt
         prompt = f"""Summarize the provided meeting audio. Only include relevant, non-discriminatory notes. 
             The current date is {get_formatted_date()}, and the meeting duration is {duration_minutes}. 
-            Use this markdown format, and fill in the date and duration, but prepend the format with 2 new lines:
+            Use this markdown format, and fill in the date and duration:
             # Meeting Summary
             ### Topic: <topic>
             ### Date: <date>
             ### Duration: <duration>
             ### Summary:
             <summary>
-            Your response can not have anything else in it but the summary.
+
+            Your response shall only contain the summary, enclosed in a multi-line code block.
             """
 
         # Send request
@@ -54,7 +55,8 @@ async def _run_gemini(audio_file_path: str, duration_minutes: str) -> str:
             os.remove(audio_file_path)
         gemini.files.delete(name=audio_file.name)
 
-        return summary.text
+        formatted_response = format_gemini_response(summary.text)
+        return formatted_response
     
     except Exception as e:
         print(f"Error in _run_gemini: {e}")

--- a/src/utils.py
+++ b/src/utils.py
@@ -27,3 +27,16 @@ def get_meeting_duration_minutes(meeting_start_time: dt | None) -> str:
     except Exception as e:
         print(f"Unexpected error: {e}")
         return "Unknown"
+    
+# Parses and formats Gemini response for a meeting summary
+def format_gemini_response(summary: str) -> str:
+    if not summary.startswith('#'):
+        counter = 1
+        # Count redundant characters (multi-line code block characters)
+        while summary[counter] != '\n':
+            counter += 1
+        
+        # Remove redundant multi-line code from both ends of the summary
+        summary = summary[counter:-3]
+
+    return summary


### PR DESCRIPTION
## Solution
After investigating, the reason for this issue seems to be in the non-deterministic nature of Gemini. Gemini seems to 'randomly' enclose the meeting summary within a multi-line code block. Tweaking the prompt was considered as a possible solution, but there was no guarantee that it would work reliably. Instead, text parsing logic was implemented for the summary, due to it being a more robust choice that can be controlled. 

The following 2 flows explain how a summary is currently being generated compared to the newly implemented flow:

### Current summary generation flow
1. Meeting ends
2. Meeting audio is saved into a .wav file
3. Meeting audio and prompt is sent to Gemini API
4. Return raw text response from Gemini

### New summary generation flow
1. Meeting ends
2. Meeting audio is saved into a .wav file
3. Meeting audio and prompt is sent to Gemini API (Prompt has been slightly tweaked)
4. Parse Gemini response and remove any multi-line code block characters
5. Return parsed response

This new flow will ensure that the non-deterministic nature of Gemini will not affect the summary sent to the end-user.

Closes #3