### PR TITLE
Resolve #2: Fix thread blocking callback function

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -91,11 +91,11 @@ async def end_meeting(ctx):
     await ctx.defer()
     if ctx.voice_client:
         try:
-            ctx.voice_client.stop_recording()
-            await ctx.voice_client.disconnect()
             await ctx.followup.send("The recording has ended and a summary is being generated.")
+            await ctx.voice_client.disconnect()
         except Exception as e:
-            await ctx.followup.send(f"Error ending meeting: {e}")
+            await ctx.followup.send("There was an error while ending the meeting.")
+            print(f"Error: {e}")
             if ctx.voice_client:
                 await ctx.voice_client.disconnect()
     else:


### PR DESCRIPTION
## Overview
After investigating, it seems that the root cause of the issue is that the `finished_recording` callback in `bot.py` is blocking the event loop, delaying the followup message for ending the meeting.

### Current bot flow for ending meetings
1. End-user ends meeting
2. Bot receives the request, and awaits a followup message
2. Bot stops recording and generates summary
3. Bot sends message `The recording has ended and a summary is being generated` in place of the awaited message
4. Bot sends summary
5. Bot disconnects from the voice channel

This flow is slightly problematic, as it only sends the followup message when the summary is sent. Additionally, it only leaves the voice channel once a summary has been sent. To address this, the following flow has been implemented:

### New bot flow for ending meetings
1. End-user ends meeting
2. Bot receives the request, and sends message `The recording has ended and a summary is being generated`
3. Bot stops recording and disconnects from the voice channel
4. Bot generates and sends summary

This new flow will be more intuitive for end-users when ending meetings, thereby improving the user experience. To implement this flow, I took advantage of the fact that the `disconnect` method implicitly stops all current actions that the bot is taking, including recording the voice channel.

Closes #2